### PR TITLE
Pass dynamic client and kube client to controllers

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -44,6 +44,12 @@
   version = "v2.4.0"
 
 [[projects]]
+  name = "github.com/emicklei/go-restful-swagger12"
+  packages = ["."]
+  revision = "dcef7f55730566d41eae5db10e7d6981829720f6"
+  version = "1.0.1"
+
+[[projects]]
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
   revision = "629574ca2a5df945712d3079857300b5e4da0236"
@@ -106,7 +112,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/golang/protobuf"
-  packages = ["proto","ptypes/any","ptypes/timestamp"]
+  packages = ["proto","ptypes","ptypes/any","ptypes/duration","ptypes/timestamp"]
   revision = "1643683e1b54a9e88ad26d98f81400c8c9d9f4f9"
 
 [[projects]]
@@ -120,6 +126,12 @@
   name = "github.com/google/gofuzz"
   packages = ["."]
   revision = "24818f796faf91cd76ec7bddd72458fbced7a6c1"
+
+[[projects]]
+  name = "github.com/googleapis/gnostic"
+  packages = ["OpenAPIv2","compiler","extensions"]
+  revision = "ee43cbb60db7bd22502942cccbc39059117352ab"
+  version = "v0.1.0"
 
 [[projects]]
   branch = "master"
@@ -291,7 +303,7 @@
 
 [[projects]]
   name = "github.com/stretchr/testify"
-  packages = ["assert","http","mock"]
+  packages = ["assert","http","mock","require"]
   revision = "69483b4bd14f5845b5a1e55bca19e954e827f1d0"
   version = "v1.1.4"
 
@@ -367,7 +379,7 @@
 
 [[projects]]
   name = "k8s.io/client-go"
-  packages = ["dynamic","kubernetes/scheme","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
+  packages = ["discovery","dynamic","kubernetes","kubernetes/scheme","kubernetes/typed/admissionregistration/v1alpha1","kubernetes/typed/apps/v1beta1","kubernetes/typed/apps/v1beta2","kubernetes/typed/authentication/v1","kubernetes/typed/authentication/v1beta1","kubernetes/typed/authorization/v1","kubernetes/typed/authorization/v1beta1","kubernetes/typed/autoscaling/v1","kubernetes/typed/autoscaling/v2beta1","kubernetes/typed/batch/v1","kubernetes/typed/batch/v1beta1","kubernetes/typed/batch/v2alpha1","kubernetes/typed/certificates/v1beta1","kubernetes/typed/core/v1","kubernetes/typed/extensions/v1beta1","kubernetes/typed/networking/v1","kubernetes/typed/policy/v1beta1","kubernetes/typed/rbac/v1","kubernetes/typed/rbac/v1alpha1","kubernetes/typed/rbac/v1beta1","kubernetes/typed/scheduling/v1alpha1","kubernetes/typed/settings/v1alpha1","kubernetes/typed/storage/v1","kubernetes/typed/storage/v1beta1","pkg/version","rest","rest/watch","tools/auth","tools/cache","tools/clientcmd","tools/clientcmd/api","tools/clientcmd/api/latest","tools/clientcmd/api/v1","tools/metrics","tools/pager","tools/reference","transport","util/cert","util/flowcontrol","util/homedir","util/integer"]
   revision = "82aa063804cf055e16e8911250f888bc216e8b61"
 
 [[projects]]
@@ -385,6 +397,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "fb0558df8060fd290a7e5ef8c4d8ce229fd29230be237e128f85cc0f53776db7"
+  inputs-digest = "166fe1effb4abaf32eb39c385d07c95f86e8fb39df9188b6d483d2e9a7f5da5f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -73,6 +73,26 @@ func TestBuildCRWatcherReturnsProperlyConfiguredWatcher(t *testing.T) {
 	assert.Equal(t, crdFilter, crw.Config.Filter)
 }
 
+func TestBuildCRWatcherReturnsNilWithInvalidKubeconfig(t *testing.T) {
+	crdGroup := "test.lostromos.k8s"
+	crdName := "testCRD"
+	crdNamespace := "lostromos"
+	crdVersion := "v9876"
+	crdFilter := "useThisResource"
+	viper.Set("crd.group", crdGroup)
+	viper.Set("crd.name", crdName)
+	viper.Set("crd.namespace", crdNamespace)
+	viper.Set("crd.version", crdVersion)
+	viper.Set("crd.filter", crdFilter)
+
+	kubeCfg := &restclient.Config{}
+	kubeCfg.Host = "http:///"
+	crw, err := buildCRWatcher(kubeCfg)
+	assert.Nil(t, crw)
+	assert.Error(t, err)
+	assert.Equal(t, "host must be a URL or a host:port pair: \"http:///\"", err.Error())
+}
+
 func TestGetControllerReturnsHelmController(t *testing.T) {
 	chart := "/path/chart"
 	ns := "lostromos"
@@ -83,7 +103,7 @@ func TestGetControllerReturnsHelmController(t *testing.T) {
 	viper.Set("helm.releasePrefix", prefix)
 	viper.Set("helm.tiller", tiller)
 
-	ctlr := getController().(*helmctlr.Controller)
+	ctlr := getController(nil).(*helmctlr.Controller)
 
 	assert.NotNil(t, ctlr)
 	assert.Equal(t, ctlr.ChartDir, chart)
@@ -98,7 +118,7 @@ func TestGetControllerReturnsTemplateController(t *testing.T) {
 	viper.Set("k8s.config", kubecfg)
 	viper.Set("helm.chart", "")
 
-	ctlr := getController().(*tmplctlr.Controller)
+	ctlr := getController(nil).(*tmplctlr.Controller)
 
 	assert.NotNil(t, ctlr)
 }

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -103,7 +103,7 @@ func TestGetControllerReturnsHelmController(t *testing.T) {
 	viper.Set("helm.releasePrefix", prefix)
 	viper.Set("helm.tiller", tiller)
 
-	ctlr := getController(nil).(*helmctlr.Controller)
+	ctlr := getController(nil, nil).(*helmctlr.Controller)
 
 	assert.NotNil(t, ctlr)
 	assert.Equal(t, ctlr.ChartDir, chart)
@@ -118,7 +118,7 @@ func TestGetControllerReturnsTemplateController(t *testing.T) {
 	viper.Set("k8s.config", kubecfg)
 	viper.Set("helm.chart", "")
 
-	ctlr := getController(nil).(*tmplctlr.Controller)
+	ctlr := getController(nil, nil).(*tmplctlr.Controller)
 
 	assert.NotNil(t, ctlr)
 }

--- a/crwatcher/watcher.go
+++ b/crwatcher/watcher.go
@@ -21,11 +21,9 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
-	restclient "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
 )
 
@@ -76,22 +74,12 @@ type ErrorLogger interface {
 }
 
 // NewCRWatcher builds a CRWatcher
-func NewCRWatcher(cfg *Config, kubeCfg *restclient.Config, rc ResourceController, l ErrorLogger) (*CRWatcher, error) {
+func NewCRWatcher(cfg *Config, dc *dynamic.Client, rc ResourceController, l ErrorLogger) (*CRWatcher, error) {
 	cw := &CRWatcher{
 		Config: cfg,
 		logger: l,
 	}
 
-	kubeCfg.ContentConfig.GroupVersion = &schema.GroupVersion{
-		Group:   cfg.Group,
-		Version: cfg.Version,
-	}
-	kubeCfg.APIPath = "apis"
-	dynClient, err := dynamic.NewClient(kubeCfg)
-	if err != nil {
-		return nil, err
-	}
-	dc := dynClient
 	cw.setupResource(dc)
 	cw.setupHandler(rc)
 	cw.setupController()

--- a/crwatcher/watcher.go
+++ b/crwatcher/watcher.go
@@ -74,7 +74,7 @@ type ErrorLogger interface {
 }
 
 // NewCRWatcher builds a CRWatcher
-func NewCRWatcher(cfg *Config, dc *dynamic.Client, rc ResourceController, l ErrorLogger) (*CRWatcher, error) {
+func NewCRWatcher(cfg *Config, dc dynamic.Interface, rc ResourceController, l ErrorLogger) (*CRWatcher, error) {
 	cw := &CRWatcher{
 		Config: cfg,
 		logger: l,
@@ -141,7 +141,7 @@ func (cw *CRWatcher) update(con ResourceController, oldR *unstructured.Unstructu
 	}
 }
 
-func (cw *CRWatcher) setupResource(dc *dynamic.Client) {
+func (cw *CRWatcher) setupResource(dc dynamic.Interface) {
 	apiResource := &metav1.APIResource{
 		Name:       cw.Config.PluralName,
 		Namespaced: cw.Config.Namespace != metav1.NamespaceNone,

--- a/helmctlr/helm.go
+++ b/helmctlr/helm.go
@@ -22,6 +22,7 @@ import (
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/helm/pkg/helm"
 	"k8s.io/helm/pkg/proto/hapi/release"
 )
@@ -38,11 +39,12 @@ type Controller struct {
 	Wait        bool           // Whether or not to wait for resources during Update and Install before marking a release successful
 	WaitTimeout int64          // time in seconds to wait for kubernetes resources to be created before marking a release successful
 	logger      *zap.SugaredLogger
-	kubeClient  *dynamic.Client
+	kubeClient  kubernetes.Interface
+	dynClient   dynamic.Interface
 }
 
 // NewController will return a configured Helm Controller
-func NewController(chartDir, ns, rn, host string, wait bool, waitto int64, logger *zap.SugaredLogger, kubeClient *dynamic.Client) *Controller {
+func NewController(chartDir, ns, rn, host string, wait bool, waitto int64, logger *zap.SugaredLogger, dynClient dynamic.Interface, kubeClient kubernetes.Interface) *Controller {
 	if logger == nil {
 		// If you don't give us a logger, set logger to a nop logger
 		logger = zap.NewNop().Sugar()
@@ -57,6 +59,7 @@ func NewController(chartDir, ns, rn, host string, wait bool, waitto int64, logge
 		ReleaseName: rn,
 		Wait:        wait,
 		WaitTimeout: waitto,
+		dynClient:   dynClient,
 		kubeClient:  kubeClient,
 		logger:      logger,
 	}

--- a/helmctlr/helm_test.go
+++ b/helmctlr/helm_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	testController  = helmctlr.NewController("../test/data/chart", "lostromos-test", "lostromostest", "0", false, 30, nil, nil)
+	testController  = helmctlr.NewController("../test/data/chart", "lostromos-test", "lostromostest", "0", false, 30, nil, nil, nil)
 	testReleaseName = "lostromostest-dory"
 	testResource    = &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -110,12 +110,12 @@ func assertCounters(t *testing.T, c counterTest, f func()) {
 }
 
 func TestNewControllerSetsNS(t *testing.T) {
-	c := helmctlr.NewController("chartDir", "", "release", "127.0.0.3:4321", false, 120, nil, nil)
+	c := helmctlr.NewController("chartDir", "", "release", "127.0.0.3:4321", false, 120, nil, nil, nil)
 	assert.Equal(t, "default", c.Namespace, "Namespace should be set to 'default' when not provided")
 	assert.Equal(t, "chartDir", c.ChartDir)
 	assert.Equal(t, "release", c.ReleaseName)
 
-	c = helmctlr.NewController("chartDir", "my_ns", "release", "127.0.0.3:4321", false, 120, nil, nil)
+	c = helmctlr.NewController("chartDir", "my_ns", "release", "127.0.0.3:4321", false, 120, nil, nil, nil)
 	assert.Equal(t, "my_ns", c.Namespace, "Namespace should be set to the value provided")
 }
 

--- a/helmctlr/helm_test.go
+++ b/helmctlr/helm_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 var (
-	testController  = helmctlr.NewController("../test/data/chart", "lostromos-test", "lostromostest", "0", false, 30, nil)
+	testController  = helmctlr.NewController("../test/data/chart", "lostromos-test", "lostromostest", "0", false, 30, nil, nil)
 	testReleaseName = "lostromostest-dory"
 	testResource    = &unstructured.Unstructured{
 		Object: map[string]interface{}{
@@ -110,12 +110,12 @@ func assertCounters(t *testing.T, c counterTest, f func()) {
 }
 
 func TestNewControllerSetsNS(t *testing.T) {
-	c := helmctlr.NewController("chartDir", "", "release", "127.0.0.3:4321", false, 120, nil)
+	c := helmctlr.NewController("chartDir", "", "release", "127.0.0.3:4321", false, 120, nil, nil)
 	assert.Equal(t, "default", c.Namespace, "Namespace should be set to 'default' when not provided")
 	assert.Equal(t, "chartDir", c.ChartDir)
 	assert.Equal(t, "release", c.ReleaseName)
 
-	c = helmctlr.NewController("chartDir", "my_ns", "release", "127.0.0.3:4321", false, 120, nil)
+	c = helmctlr.NewController("chartDir", "my_ns", "release", "127.0.0.3:4321", false, 120, nil, nil)
 	assert.Equal(t, "my_ns", c.Namespace, "Namespace should be set to the value provided")
 }
 

--- a/tmplctlr/controller.go
+++ b/tmplctlr/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/wpengine/lostromos/tmpl"
 	"go.uber.org/zap"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/client-go/dynamic"
 )
 
 // Controller implements a valid crwatcher.ResourceController that will manage
@@ -31,10 +32,11 @@ type Controller struct {
 	templatePath string     //path to dir where templates are located
 	Client       KubeClient //client for talking with kubernetes
 	logger       *zap.SugaredLogger
+	kubeClient   *dynamic.Client
 }
 
 // NewController will return a configured Controller
-func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger) *Controller {
+func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger, kubeClient *dynamic.Client) *Controller {
 	if logger == nil {
 		// If you don't give us a logger, set logger to a nop logger
 		logger = zap.NewNop().Sugar()
@@ -43,6 +45,7 @@ func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger) *C
 		Client:       &Kubectl{ConfigFile: kubeCfg},
 		templatePath: filepath.Join(tmplDir, "*.tmpl"),
 		logger:       logger,
+		kubeClient:   kubeClient,
 	}
 	return c
 }

--- a/tmplctlr/controller.go
+++ b/tmplctlr/controller.go
@@ -32,11 +32,11 @@ type Controller struct {
 	templatePath string     //path to dir where templates are located
 	Client       KubeClient //client for talking with kubernetes
 	logger       *zap.SugaredLogger
-	kubeClient   *dynamic.Client
+	dynClient    dynamic.Interface
 }
 
 // NewController will return a configured Controller
-func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger, kubeClient *dynamic.Client) *Controller {
+func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger, dynClient dynamic.Interface) *Controller {
 	if logger == nil {
 		// If you don't give us a logger, set logger to a nop logger
 		logger = zap.NewNop().Sugar()
@@ -45,7 +45,7 @@ func NewController(tmplDir string, kubeCfg string, logger *zap.SugaredLogger, ku
 		Client:       &Kubectl{ConfigFile: kubeCfg},
 		templatePath: filepath.Join(tmplDir, "*.tmpl"),
 		logger:       logger,
-		kubeClient:   kubeClient,
+		dynClient:    dynClient,
 	}
 	return c
 }

--- a/tmplctlr/controller_test.go
+++ b/tmplctlr/controller_test.go
@@ -150,7 +150,7 @@ func TestResourceAddedHappyPath(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -172,7 +172,7 @@ func TestResourceAddedApplyFails(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -193,7 +193,7 @@ func TestResourceAddedTemplatingFails(t *testing.T) {
 	dir := createTestDir(testBadTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -212,7 +212,7 @@ func TestResourceDeletedHappyPath(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -234,7 +234,7 @@ func TestResourceDeletedApplyFails(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -255,7 +255,7 @@ func TestResourceDeletedTemplatingFails(t *testing.T) {
 	dir := createTestDir(testBadTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -274,7 +274,7 @@ func TestResourceUpdatedHappyPath(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)
@@ -295,7 +295,7 @@ func TestResourceUpdatedApplyFails(t *testing.T) {
 	dir := createTestDir(testTemplates)
 	// Clean up after the test; another quirk of running as an example.
 	defer os.RemoveAll(dir)
-	c := tmplctlr.NewController(dir, "", nil)
+	c := tmplctlr.NewController(dir, "", nil, nil)
 	mockCtrl := gomock.NewController(t)
 	defer mockCtrl.Finish()
 	mockKube := NewMockKubeClient(mockCtrl)


### PR DESCRIPTION
Needed for later changes which involve updating the CR status, and
querying the Kubernetes API directly, for when we need to check the
uncached version of a resource.