### PR TITLE
Set OwnerReferences on helm release configmaps after install/upgrade

### DIFF
--- a/helmctlr/helm.go
+++ b/helmctlr/helm.go
@@ -43,7 +43,7 @@ type Controller struct {
 	Wait           bool           // Whether or not to wait for resources during Update and Install before marking a release successful
 	WaitTimeout    int64          // time in seconds to wait for kubernetes resources to be created before marking a release successful
 	logger         *zap.SugaredLogger
-	KubeClient     kubernetes.Interface
+	kubeClient     kubernetes.Interface
 	resourceClient dynamic.ResourceInterface
 }
 
@@ -64,7 +64,7 @@ func NewController(chartDir, ns, rn, host string, wait bool, waitto int64, logge
 		Wait:           wait,
 		WaitTimeout:    waitto,
 		resourceClient: resourceClient,
-		KubeClient:     kubeClient,
+		kubeClient:     kubeClient,
 		logger:         logger,
 	}
 	return c
@@ -193,7 +193,7 @@ func (c Controller) setReleaseConfigMapOwnerReferences(r *unstructured.Unstructu
 	opts := metav1.ListOptions{
 		LabelSelector: selector.String(),
 	}
-	helmReleaseConfigMaps, err := c.KubeClient.CoreV1().ConfigMaps(c.Namespace).List(opts)
+	helmReleaseConfigMaps, err := c.kubeClient.CoreV1().ConfigMaps(c.Namespace).List(opts)
 	if err != nil {
 		return err
 	}
@@ -211,7 +211,7 @@ func (c Controller) setReleaseConfigMapOwnerReferences(r *unstructured.Unstructu
 			*controllerRef,
 		}
 		releaseCM.SetOwnerReferences(ownerRefs)
-		_, err = c.KubeClient.CoreV1().ConfigMaps(c.Namespace).Update(&releaseCM)
+		_, err = c.kubeClient.CoreV1().ConfigMaps(c.Namespace).Update(&releaseCM)
 		if err != nil {
 			return err
 		}

--- a/helmctlr/helm.go
+++ b/helmctlr/helm.go
@@ -31,6 +31,8 @@ import (
 
 var defaultNS = "default"
 
+const tillerOwnerLabelValue = "TILLER"
+
 // Controller is a crwatcher.ResourceController that works with Helm to deploy
 // helm charts into K8s providing a CustomResource as value data to the charts
 type Controller struct {
@@ -173,7 +175,7 @@ func (c Controller) setReleaseConfigMapOwnerReferences(r *unstructured.Unstructu
 	rlsName := c.releaseName(r)
 	selector, err := metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchLabels: map[string]string{
-			"OWNER": "TILLER",
+			"OWNER": tillerOwnerLabelValue,
 			"NAME":  rlsName,
 		},
 	})


### PR DESCRIPTION
The OwnerReference is set to the CR that triggered the install/upgrade,
meaning if the CR is deleted, the helm release configMaps are also
deleted.

Before this completely works, we'll need to also set ownerReferences of the resources created from helm, and remove the logic for running `helm delete`, as the release configMap will be deleted when the CR is, and helm will be unable to find the release when it attempts to run helm delete.